### PR TITLE
Add matching directory hierarchies for the Components and Style folders

### DIFF
--- a/styles/globals copy.css
+++ b/styles/globals copy.css
@@ -1,0 +1,16 @@
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
+    Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}


### PR DESCRIPTION
Closes #54. Added a base for a hierarchical directory structure for the components and style folders. This helps better organise the files for later work, and also mitigates any duplicate component naming issues.