### PR TITLE
Go to Home when you click the site logo on header

### DIFF
--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -5,7 +5,9 @@ export default function SiteHeader() {
   return (
     <nav className="md:h-[56px] p-0 justify-between bg-white shadow-[0_0px_4px_4px_rgba(0,0,0,0.25)] sticky top-0">
       <div className="h-full md:flex md:justify-between md:items-center max-w-7xl mx-auto">
-        <img className="h-[56px] md:max-h-full pl-4 pt-2" src={logo.src} alt="Nebula logo" />
+        <Link href="/">
+          <img className="h-[56px] md:max-h-full pl-4 pt-2" src={logo.src} alt="Nebula logo" />
+        </Link>
         <div className="p-3 md:flex md:justify-between md:space-x-4">
           <Link
             href="/#featured"


### PR DESCRIPTION
## Overview

closes #69 

Describe your changes here at a high level, describing how this PR fits into the
rest of the project.

You can now navigate to the homepage by clicking on the site logo on the header

## What Changed

I modified the SiteHeader.tsx to wrap the link element around the site logo on the header so it goes to the homepage when you click on it.

## Other Notes

