### PR TITLE
Implement UI for a glossary of terms

### DIFF
--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -15,6 +15,12 @@ export default function SiteHeader() {
           >
             Articles
           </Link>
+          <Link
+            href="/glossary"
+            className="block text-center p-2 w-full md:w-auto rounded-full text-white font-bold bg-[#4659A7] hover:bg-[#3D4E94]"
+          >
+            Glossary
+          </Link>
         </div>
       </div>
     </nav>

--- a/data/test_glossary_entries.json
+++ b/data/test_glossary_entries.json
@@ -1,0 +1,30 @@
+[
+    {
+       "term": "Temoc",
+        "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    },
+    {
+        "term": "Tobor",
+        "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+    },
+    {
+        "term": "Enarc",
+        "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla paria."
+    },
+    {
+        "term": "Placeholder",
+        "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+    },
+    {
+        "term": "Placeholder",
+        "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat."
+    },
+    {
+        "term": "Placeholder",
+        "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    },
+    {
+        "term": "Placeholder",
+        "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla."
+    }
+]

--- a/pages/glossary.tsx
+++ b/pages/glossary.tsx
@@ -1,50 +1,48 @@
 import Link from 'next/link';
 import testGlossaryEntries from '../data/test_glossary_entries.json';
 import type {
-    GetStaticPathsResult,
-    GetStaticPropsContext,
-    GetStaticPropsResult,
-    InferGetStaticPropsType,
-  } from 'next/types';
+  GetStaticPathsResult,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+  InferGetStaticPropsType,
+} from 'next/types';
 import SiteFooter from '../components/SiteFooter';
 
-export default function glossary(entry : InferGetStaticPropsType<typeof getStaticProps>) {
-  console.log(entry);
-  const glossaryEntries = entry.entry.map(glossaryEntry =>  
+export default function glossary(entry: InferGetStaticPropsType<typeof getStaticProps>) {
+  const glossaryEntries = entry.entry.map((glossaryEntry) => (
     <div key={glossaryEntry.term}>
-      <p className='text-lg font-semibold'>{glossaryEntry.term}</p>
+      <p className="text-lg font-semibold">{glossaryEntry.term}</p>
       <br />
-      <p className='text-sm font-normal text-zinc-600'>{glossaryEntry.content}</p>
+      <p className="text-sm font-normal text-zinc-600">{glossaryEntry.content}</p>
       <br />
-    </div>   
-  );
+    </div>
+  ));
   return (
-    <div className='bg-[#e0ecfb]'>
-    <main className="p-16">
-      <div className="max-w-4xl mx-auto space-y-4">
-        <div className="p-12 bg-white rounded-xl shadow-md">
-          <h1 className="text-headline4 text-[96px] font-bold font-display">Glossary</h1>
-          
-          <br />
-          {glossaryEntries}
-          
+    <div className="bg-[#e0ecfb]">
+      <main className="p-16">
+        <div className="max-w-4xl mx-auto space-y-4">
+          <div className="p-12 bg-white rounded-xl shadow-md">
+            <h1 className="text-headline4 text-[96px] font-bold font-display">Glossary</h1>
+
+            <br />
+            {glossaryEntries}
+          </div>
         </div>
-      </div>
-    </main>
+      </main>
       <SiteFooter />
     </div>
   );
 }
 
 type GlossaryEntry = {
-  term: string,
-  content: string
+  term: string;
+  content: string;
 };
 
 type GlossaryEntries = GlossaryEntry[];
 
 type EntryPageProps = {
-    entry: GlossaryEntries;
+  entry: GlossaryEntries;
 };
 
 /**
@@ -53,14 +51,14 @@ type EntryPageProps = {
  * At build time, this gets the data for a Guide entry from our data source.
  */
 export async function getStaticProps({
-    params,
-  }: GetStaticPropsContext): Promise<GetStaticPropsResult<EntryPageProps>> {
-    const data = await getGlossaryEntryData();
-    return {
-      props: {
-        entry: data
-      }
-    };
+  params,
+}: GetStaticPropsContext): Promise<GetStaticPropsResult<EntryPageProps>> {
+  const data = await getGlossaryEntryData();
+  return {
+    props: {
+      entry: data,
+    },
+  };
 }
 
 /**

--- a/pages/glossary.tsx
+++ b/pages/glossary.tsx
@@ -13,8 +13,8 @@ export default function glossary() {
       <main className="p-16">
         <div className="max-w-4xl mx-auto space-y-4">
           <div className="p-12 bg-white rounded-xl shadow-md">
-            <h1 className="text-headline4 text-[96px] font-bold font-display">I got you NIgga</h1>
-            <div className="text-4xl">We couldn&apos;t find what you were looking for NIgga.</div>
+            <h1 className="text-headline4 text-[96px] font-bold font-display">Work In progress</h1>
+            <div className="text-4xl">Will be filled in later</div>
             <div className="mt-4 text-lg text-2xl">
               Go{' '}
               <Link
@@ -67,33 +67,5 @@ export async function getStaticProps({
  * @returns Guide entry data
  */
 async function getEntryData(): Promise<GlossaryEntries> {
-    let list: string;
-    for(let i = 0; i < testGlossaryEntries.length; i++){
-        let entry : GlossaryEntry;
-        entry = {term: testGlossaryEntries[i].term, content: testGlossaryEntries[i].content}
-        list += {GlossaryEntryList : [entry]}
-    }
-    if(list === null){
-        throw new Error('Invalid ');
-    }
-    else{
-        return list;
-    }
-    
-    // const entry = testGlossaryEntries.find((entry) => list += [term: entry.term, content : entry.content]:Promise<GlossaryEntry>);
-    // if(list){
-    //     return list;
-    // }else{
-    //     throw new Error('Invalid entry ID provided');
-    // }
-    // if (entry) {
-    //   const data = {
-    //     ...entry,
-    //     lastUpdated: new Date(entry.lastUpdated).valueOf(),
-    //     content: (await remark().use(html).process(entry.content)).toString(),
-    //   };
-    //   return data;
-    // } else {
-    //   throw new Error('Invalid entry ID provided.');
-    // }
-  }
+    var list = testGlossaryEntries.map()
+}

--- a/pages/glossary.tsx
+++ b/pages/glossary.tsx
@@ -1,0 +1,99 @@
+import Link from 'next/link';
+import testGlossaryEntries from '../data/test_glossary_entries.json';
+import type {
+    GetStaticPathsResult,
+    GetStaticPropsContext,
+    GetStaticPropsResult,
+    InferGetStaticPropsType,
+  } from 'next/types';
+
+export default function glossary() {
+  return (
+    <div className="min-h-screen bg-slate-100 bg-[url(/nebula_background.svg)] bg-cover">
+      <main className="p-16">
+        <div className="max-w-4xl mx-auto space-y-4">
+          <div className="p-12 bg-white rounded-xl shadow-md">
+            <h1 className="text-headline4 text-[96px] font-bold font-display">I got you NIgga</h1>
+            <div className="text-4xl">We couldn&apos;t find what you were looking for NIgga.</div>
+            <div className="mt-4 text-lg text-2xl">
+              Go{' '}
+              <Link
+                href="/"
+                className="text-primary font-semibold underline hover:text-primary-dark transition-all ease-in-out"
+              >
+                home
+              </Link>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+type GlossaryEntry = {
+    term: string,
+    content: string
+};
+
+type GlossaryEntries = {
+    GlossaryEntryList: GlossaryEntry[];
+};
+
+type EntryPageProps = {
+    entry: GlossaryEntry;
+};
+
+/**
+ * Fetches entry data.
+ *
+ * At build time, this gets the data for a Guide entry from our data source.
+ */
+export async function getStaticProps({
+    params,
+  }: GetStaticPropsContext): Promise<GetStaticPropsResult<EntryPageProps>> {
+    const data = await getEntryData();
+    return {
+      props: {
+        entry: data,
+      },
+    };
+}
+
+/**
+ * Fetches data for one Guide entry page.
+ *
+ * @param id
+ * @returns Guide entry data
+ */
+async function getEntryData(): Promise<GlossaryEntries> {
+    let list: string;
+    for(let i = 0; i < testGlossaryEntries.length; i++){
+        let entry : GlossaryEntry;
+        entry = {term: testGlossaryEntries[i].term, content: testGlossaryEntries[i].content}
+        list += {GlossaryEntryList : [entry]}
+    }
+    if(list === null){
+        throw new Error('Invalid ');
+    }
+    else{
+        return list;
+    }
+    
+    // const entry = testGlossaryEntries.find((entry) => list += [term: entry.term, content : entry.content]:Promise<GlossaryEntry>);
+    // if(list){
+    //     return list;
+    // }else{
+    //     throw new Error('Invalid entry ID provided');
+    // }
+    // if (entry) {
+    //   const data = {
+    //     ...entry,
+    //     lastUpdated: new Date(entry.lastUpdated).valueOf(),
+    //     content: (await remark().use(html).process(entry.content)).toString(),
+    //   };
+    //   return data;
+    // } else {
+    //   throw new Error('Invalid entry ID provided.');
+    // }
+  }

--- a/pages/glossary.tsx
+++ b/pages/glossary.tsx
@@ -6,66 +6,68 @@ import type {
     GetStaticPropsResult,
     InferGetStaticPropsType,
   } from 'next/types';
+import SiteFooter from '../components/SiteFooter';
 
-export default function glossary() {
+export default function glossary(entry : InferGetStaticPropsType<typeof getStaticProps>) {
+  console.log(entry);
+  const glossaryEntries = entry.entry.map(glossaryEntry =>  
+    <div key={glossaryEntry.term}>
+      <p className='text-lg font-semibold'>{glossaryEntry.term}</p>
+      <br />
+      <p className='text-sm font-normal text-zinc-600'>{glossaryEntry.content}</p>
+      <br />
+    </div>   
+  );
   return (
-    <div className="min-h-screen bg-slate-100 bg-[url(/nebula_background.svg)] bg-cover">
-      <main className="p-16">
-        <div className="max-w-4xl mx-auto space-y-4">
-          <div className="p-12 bg-white rounded-xl shadow-md">
-            <h1 className="text-headline4 text-[96px] font-bold font-display">Work In progress</h1>
-            <div className="text-4xl">Will be filled in later</div>
-            <div className="mt-4 text-lg text-2xl">
-              Go{' '}
-              <Link
-                href="/"
-                className="text-primary font-semibold underline hover:text-primary-dark transition-all ease-in-out"
-              >
-                home
-              </Link>
-            </div>
-          </div>
+    <div className='bg-[#e0ecfb]'>
+    <main className="p-16">
+      <div className="max-w-4xl mx-auto space-y-4">
+        <div className="p-12 bg-white rounded-xl shadow-md">
+          <h1 className="text-headline4 text-[96px] font-bold font-display">Glossary</h1>
+          
+          <br />
+          {glossaryEntries}
+          
         </div>
-      </main>
+      </div>
+    </main>
+      <SiteFooter />
     </div>
   );
 }
 
 type GlossaryEntry = {
-    term: string,
-    content: string
+  term: string,
+  content: string
 };
 
-type GlossaryEntries = {
-    GlossaryEntryList: GlossaryEntry[];
-};
+type GlossaryEntries = GlossaryEntry[];
 
 type EntryPageProps = {
-    entry: GlossaryEntry;
+    entry: GlossaryEntries;
 };
 
 /**
- * Fetches entry data.
+ * Fetches glossary entry data.
  *
  * At build time, this gets the data for a Guide entry from our data source.
  */
 export async function getStaticProps({
     params,
   }: GetStaticPropsContext): Promise<GetStaticPropsResult<EntryPageProps>> {
-    const data = await getEntryData();
+    const data = await getGlossaryEntryData();
     return {
       props: {
-        entry: data,
-      },
+        entry: data
+      }
     };
 }
 
 /**
- * Fetches data for one Guide entry page.
+ * Fetches data of all glossary entries for the glossary page.
  *
- * @param id
- * @returns Guide entry data
+ * @returns  glossary entry data
  */
-async function getEntryData(): Promise<GlossaryEntries> {
-    var list = testGlossaryEntries.map()
+async function getGlossaryEntryData(): Promise<GlossaryEntries> {
+  return testGlossaryEntries;
 }


### PR DESCRIPTION
## Overview

Closes #62 

This creates a glossary page with terms and content accessible at the /glossary route.

## What Changed

I added a glossary.tsx to the pages folder to create a new glossary page and then created dummy data in GlossaryEntriesData.json to test it within the data folder. the glossary page renders the data into divs of terms and content.

## Other Notes

I'm not sure if I got the exact styles right so I would like to see if the styles are alright. I tested it with dummy data.
